### PR TITLE
Suggesting Creative Commons BY 4.0 License

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,6 @@ engineering. We'd like to continue maintaining them in that way so...
 Issues and pull requests will be reviewed by the Principal and Distinguished
 Engineers in the Scout24 group, who are responsible for keeping this up to date,
 and you'll get feedback. Too easy!
+
+## License
+[Creative commons Attribution 4.0 International (CC BY 4.0)](http://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
We are required to specify a license for public repos. And I think creative commons would be a good choice here. The license I picked will allow commercial use and modification. Which should be fine for this information. 